### PR TITLE
Add modules interop.

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,9 @@ import('whatever').then(onwhatever)
 ```js
 var _import = require('split-require');
 
-_import("whatever").then(onwhatever);
+function _interopRequireDefault(obj) { return /* ... */ }
+
+_import("whatever").then(_interopRequireDefault).then(onwhatever);
 ```
 
 This code can be bundled by browserify using the [`split-require`](https://github.com/goto-bus-stop/split-require#readme) plugin.

--- a/index.js
+++ b/index.js
@@ -3,6 +3,10 @@ module.exports = function (babel) {
     require('split-require')
   `)
 
+  var makeDefaultWrapper = babel.template(`
+    IMPORT.then(HELPER)
+  `)
+
   return {
     inherits: require('babel-plugin-syntax-dynamic-import'),
 
@@ -25,6 +29,10 @@ module.exports = function (babel) {
         if (path.get('callee').isImport()) {
           this.usesImport = true
           path.get('callee').replaceWith(this.helperId)
+          path.replaceWith(makeDefaultWrapper({
+            IMPORT: path.node,
+            HELPER: this.file.addHelper('interopRequireDefault')
+          }))
         }
       }
     }

--- a/test/index.js
+++ b/test/index.js
@@ -9,7 +9,7 @@ test('transforms import() to a split-require helper', function (t) {
 
   var src = babel.transform(dedent`
     import('./whatever').then((whatever) => {
-      console.log(whatever)
+      console.log(whatever.default)
     })
   `, {
     plugins: [ plugin ]
@@ -18,8 +18,10 @@ test('transforms import() to a split-require helper', function (t) {
   t.equal(src, dedent`
     var _import = require('split-require');
 
-    _import('./whatever').then(whatever => {
-      console.log(whatever);
+    function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+    _import('./whatever').then(_interopRequireDefault).then(whatever => {
+      console.log(whatever.default);
     });
   `)
 })


### PR DESCRIPTION
So that `import()` acts similarly to `import` statements.

If a split module contains a transpiled ES module, its namespace object
is returned.
If it contains an untranspiled CJS module, the entire object is placed
on the `.default` property.